### PR TITLE
`browserid_js_tag` can now take params

### DIFF
--- a/lib/devise_browserid_authenticatable/view_helpers.rb
+++ b/lib/devise_browserid_authenticatable/view_helpers.rb
@@ -1,10 +1,10 @@
 module BrowserId
   module ViewHelpers
-    def browserid_js_tag
-      javascript_include_tag(include_js_url)
+    def browserid_js_tag(params = {})
+      javascript_include_tag(browserid_js_include_url, params)
     end
 
-    def include_js_url
+    def browserid_js_include_url
       "https://#{Devise::Strategies::BrowseridAuthenticatable.browserid_url}/include.js"
     end
   end


### PR DESCRIPTION
Also, `include_js_url` renamed to avoid collisions.
