### PR TITLE
New URLs for persona.org

### DIFF
--- a/lib/devise_browserid_authenticatable/strategy.rb
+++ b/lib/devise_browserid_authenticatable/strategy.rb
@@ -34,9 +34,9 @@ class Devise::Strategies::BrowseridAuthenticatable < Devise::Strategies::Authent
 
   def self.browserid_url
     if Rails.env.production?
-      "browserid.org"
+      "login.persona.org"
     else
-      "dev.diresworb.org"
+      "login.dev.anosrep.org"
     end
   end
 end


### PR DESCRIPTION
Mozilla's new urls are on persona.org. (Old URLs still work but are now 301 redirects…)
